### PR TITLE
Add sample command for testing a single role

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ docker run --rm -v $(pwd):/data cytopia/ansible-lint playbook.yml
 
 # All playbooks via wildcard
 docker run --rm -v $(pwd):/data cytopia/ansible-lint *.yml
+
+# Single role (run from within the role's root)
+docker run --rm -v "$(pwd)":"/data/$(basename "$(pwd)" )" -e ANSIBLE_ROLES_PATH="/data" cytopia/ansible-lint "/data/$(basename "$(pwd)" )/tests/test.yml"
 ```
 
 


### PR DESCRIPTION
I've added an example command for testing a single Ansible role.  For
example, suppose I have a role named 'myrole' which I want to test
independently (e.g., the role has its own repository); I can then go to
the role's root directory and run the example command to run
`ansible-lint` on it.

So, if the role lives at:

~/src/myrole/

then I would go to ~/src/myrole/ and run the sample command provided
(included below for your reference):

```
cd ~/src/myrole

docker run --rm \
  -v "$(pwd)":"/data/$(basename "$(pwd)" )" \
  -e ANSIBLE_ROLES_PATH="/data" \
  cytopia/ansible-lint \
  "/data/$(basename "$(pwd)" )/tests/test.yml"
```

This assumes one uses `ansible-galaxy init` to create the role's
directory structure (i.e., 'tests/test.yml' needs to exist).

I use this frequently (I've an alias to run the test) as I typically
have one role per repository such that the code can more easily be
re-used by multiple playbooks.  As a result, there often isn't a playbook
file (hence the use of tests/test.yml)...  so... this.