### PR TITLE
Add default dir as git safe directory

### DIFF
--- a/Dockerfiles/Dockerfile.latest
+++ b/Dockerfiles/Dockerfile.latest
@@ -69,7 +69,9 @@ RUN set -eux \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
-RUN echo -en "[safe]\n        directory = /data\n" >> /root/.gitconfig
+RUN set -eux \
+	&& echo -en "[safe]\n    directory = /data\n" >> /root/.gitconfig
+
 WORKDIR /data
 ENTRYPOINT ["ansible-lint"]
 CMD ["--version"]

--- a/Dockerfiles/Dockerfile.latest
+++ b/Dockerfiles/Dockerfile.latest
@@ -68,6 +68,7 @@ RUN set -eux \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
+RUN echo -en "[safe]\n        directory = /data\n" >> /root/.gitconfig
 WORKDIR /data
 ENTRYPOINT ["ansible-lint"]
 CMD ["--version"]


### PR DESCRIPTION
Git introduced the usage of `safe.directory` in response to the security vulnerability CVE-2022-24765. When running `ansible-lint`, the directory mounted to `/data` is often not root-owned, but `/data is, so we get errors:

Failed to guess project directory using git: fatal: detected dubious ownership in repository at '/data'
To add an exception for this directory, call:
	git config --global --add safe.directory /data
WARNING  Failed to discover lintable files using git: fatal: detected dubious ownership in repository at '/data'

This commit creates a `/root/.gitconfig` including `/data` as safe directory.