### PR TITLE
update to alpine:3.18

### DIFF
--- a/Dockerfiles/Dockerfile.latest
+++ b/Dockerfiles/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as builder
+FROM alpine:3.18 as builder
 
 RUN set -eux \
 	&& apk add --no-cache \
@@ -30,7 +30,7 @@ RUN set -eux \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
 
-FROM alpine:3.16 as production
+FROM alpine:3.18 as production
 ARG VERSION
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 #LABEL "org.opencontainers.image.created"=""
@@ -55,7 +55,7 @@ RUN set -eux \
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
 
-COPY --from=builder /usr/lib/python3.10/site-packages/ /usr/lib/python3.10/site-packages/
+COPY --from=builder /usr/lib/python3.11/site-packages/ /usr/lib/python3.11/site-packages/
 COPY --from=builder /usr/bin/ansible-lint /usr/bin/ansible-lint
 COPY --from=builder /usr/bin/ansible /usr/bin/ansible
 COPY --from=builder /usr/bin/ansible-config /usr/bin/ansible-config


### PR DESCRIPTION
fix https://github.com/cytopia/docker-ansible-lint/issues/36

error does not happen with alpine 3.18 as it does not contain conflicting version of "packaging" package.